### PR TITLE
Remove default server URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ But this feature requires some non trivial actions, as described in the [related
 The `sendTuleapStatus` step simplifies this action.
 The expected parameters:
 
-* `tuleapServer`: Server's URL (example: `https://tuleap.exampe.com`). By default, URL of [Tuleap](https://tuleap.net) is used.
+* `tuleapServer`: Server's URL (example: `https://tuleap.example.com`).
 * `targetRepo`: Path to the repository (example: `project-name/repo-name.git`).
 * `status`: Effective status (`"success"` / `"failure"`). If not set, the status is based on the current build (cf. `${currentBuild.currentResult}`).
 * `gitToken`: Specific token to access the API. This token can be retrieved in the administration dashboard of the repository, in the **Token** tab.

--- a/vars/sendTuleapStatus.groovy
+++ b/vars/sendTuleapStatus.groovy
@@ -18,11 +18,11 @@ def call(Map config) {
 
   // Configuration de la step :
   //   gitToken : Token d'accès au dépot GIT
-  //   tuleapServer : chemin vers le server Tuleap (tuleap.net par defaut)
+  //   tuleapServer : chemin vers le server Tuleap
   //   targetRepo : ID ou chemin du dépot
   //   status : success / failure
   def gitToken = config.gitToken
-  def serverPath = config.tuleapServer ?: "https://tuleap.net"
+  def serverPath = config.tuleapServer
   def targetRepoId = config.targetRepo ? URLEncoder.encode(config.targetRepo, "UTF-8") : 0
   def status = config.status
   if (config.status == null) {
@@ -35,6 +35,10 @@ def call(Map config) {
   }
   // Ensure status is lower case (for example, currentBuild is upper case)
   status = status.toLowerCase()
+
+  if (serverPath == null) {
+    error "The tuleapServer parameter must be set"
+  }
 
   // récupération de l'ID du dernier commit
   def version = sh( script: 'git rev-parse HEAD', returnStdout: true).toString().trim()

--- a/vars/sendTuleapStatus.txt
+++ b/vars/sendTuleapStatus.txt
@@ -1,4 +1,4 @@
-* `tuleapServer`: Server's URL (example: `https://tuleap.net`). By default, URL of [Odin](https://tuleap.net) is used.
+* `tuleapServer`: Server's URL (example: `https://tuleap.example.com`).
 * `targetRepo`: Path to the repository (example: `project-name/repo-name.git`).
 * `status`: Effective status (`"success"` / `"failure"`). If not set, the status is based on the current build (cf. `${currentBuild.currentResult}`).
 * `gitToken`: Specific token to access the API. This token can be retrieved in the administration dashboard of the repository, in the **Token** tab.


### PR DESCRIPTION
The usage of https://tuleap.net is very circumstantial as it only makes
sense for the users of Tuleap.net playing with CI jobs (i.e. mainly Tuleap core
devs). Virtually everyone will be forced to set the server's URL anyway.

From past experiences, it might be better to have an hard crash instead of
something that tries to query a real Tuleap instance. Debugging and understanding
of what the issue is gets easier. Also, from a privacy point of view it makes
sure users of the library does not leak the existence (and more, user agents are
verbose) of their Jenkins instance inadvertently.



Thanks for publishing your library, it makes things a lot easier :+1: .